### PR TITLE
Some improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,13 +105,23 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
     <profiles>
+        <profile>
+            <id>stageDataset</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>stageFileItem</id>
             <activation>

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
@@ -42,9 +42,8 @@ object EasyStageFileItem {
       _             <- mkdirSafe(s.sdoSetDir)
       datasetSdoDir <- mkdirSafe(new File(s.sdoSetDir, s.datasetId.replace(":", "_")))
       sdoDir        <- mkdirSafe(new File(datasetSdoDir, toSdoName(s.filePath)))
-      parentSdoDir  =  if(s.filePath.getParentFile == null) datasetSdoDir
-                       else new File(datasetSdoDir, toSdoName(s.filePath.getParentFile))
-      _             <- if (parentId.isDefined || parentSdoDir.isDirectory) Success()
+      parentSdoDir  =  Option(s.filePath.getParentFile).map(f => new File(datasetSdoDir, toSdoName(f))).getOrElse(datasetSdoDir)
+      _             <- if (parentId.isDefined || parentSdoDir.isDirectory) Success(Unit)
                        else Failure(new scala.Exception(s"${parentSdoDir.getName} was not staged"))
       _             <- if (s.file.isDefined) createFileSdo(sdoDir, parentId, parentSdoDir)
                        else createFolderSdo(sdoDir, parentId, parentSdoDir)


### PR DESCRIPTION
Suggesting some improvements on the pull request:
* Avoid a Maven warning by moving the default `maven-exec-plugin` config to a profile as well.
* The second suggestion was created by Georgi. The other "if-else" constructs in the same for comprehension need to be reconsidered as well.

I'll continue reviewing this later and will probably suggesting some more changes.

The build is now warning free. The scala compiler plug-in config has been improved to clearly show and explain deprecation warnings. Let's try and keep the build warning free.